### PR TITLE
bug fix packaging + fix printing with deletion of `str()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # Tests
 tests.py
+
+# PyPi
+.pypirc

--- a/examples/udict.md
+++ b/examples/udict.md
@@ -174,7 +174,7 @@ print(('hi', 1) in d) # True
 print(('hi', 11) in d) # False
 ```
 
-## Using in `repr()` method
+## Using `repr()` and `print()`
 
 `print()` uses `repr()` therefore you can use `UDict`s in `print()`
 

--- a/examples/udict.md
+++ b/examples/udict.md
@@ -174,25 +174,14 @@ print(('hi', 1) in d) # True
 print(('hi', 11) in d) # False
 ```
 
-## Convert to `str` type and using in `print`
+## Using in `repr()` method
 
-### Print dict
-
-`print` uses `repr()` therefore `UDict` supports `repr()`
+`print()` uses `repr()` therefore you can use `UDict`s in `print()`
 
 ```python
 d = UDict(hi=1, hello=2)
 print(d) # u{'hi': 1, 'hello': 2}
 print(repr(d)) # u{'hi': 1, 'hello': 2}
-```
-
-### Convert to str
-
-You can use inbuilt `str()` class for converting `UDict` to `str` type
-
-```python
-d = UDict(hi=1, hello=2)
-print(str(d)) # {'hi': 1, 'hello': 2}
 ```
 
 ## Comparing dicts

--- a/examples/udict.md
+++ b/examples/udict.md
@@ -176,7 +176,7 @@ print(('hi', 11) in d) # False
 
 ## Using `repr()` and `print()`
 
-`print()` uses `repr()` therefore you can use `UDict`s in `print()`
+Since `print()` uses `repr()`, you can directly print `UDict` objects.
 
 ```python
 d = UDict(hi=1, hello=2)

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ from ufpy import __version__
 with open('README.md', 'r', encoding='utf-8') as mdf:
     long_description = mdf.read()
 
-with open('requirements.txt', 'r', encoding='utf-8') as rqf:
-    install_requires = rqf.readlines()
+install_requires = [
+
+]
 
 organization_name = 'honey-team'
 author, author_email = 'bleudev', 'aitiiigg1@gmail.com'
@@ -23,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url=github_url,
-    packages=[project_name],
+    packages=[project_name, f'{project_name}.typ'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.12',

--- a/tests/test_udict.py
+++ b/tests/test_udict.py
@@ -147,11 +147,10 @@ class UDictTestCase(unittest.TestCase):
         self.assertTrue(('hi', 2) in d)
         self.assertFalse(('hi', 1) in d)
 
-    def test_str_and_repr(self):
+    def test_repr(self):
         d = {'hello': 1, 'hi': 2}
         ud = UDict(d)
 
-        self.assertEqual(str(ud), str(d))
         self.assertEqual(repr(ud), f'u{repr(d)}')
 
     def test_cmp_and_eq(self):

--- a/ufpy/__init__.py
+++ b/ufpy/__init__.py
@@ -1,8 +1,12 @@
-__version__ = '0.1.1'
+__version__ = '0.1.1.2'
 
-from .cmp import *
-from .math_op import *
-from .path_tools import *
-from .udict import *
-from .ustack import *
-from .utils import *
+# Typing package
+from ufpy import typ
+from ufpy.cmp import *
+from ufpy.math_op import *
+from ufpy.path_tools import *
+from ufpy.typ.protocols import *
+from ufpy.typ.type_alias import *
+from ufpy.udict import *
+from ufpy.ustack import *
+from ufpy.utils import *

--- a/ufpy/__init__.py
+++ b/ufpy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.1.2'
+__version__ = '0.1.2'
 
 # Typing package
 from ufpy import typ

--- a/ufpy/typ/__init__.py
+++ b/ufpy/typ/__init__.py
@@ -1,2 +1,2 @@
-from .protocols import *
-from .type_alias import *
+from ufpy.typ.protocols import *
+from ufpy.typ.type_alias import *

--- a/ufpy/typ/type_alias.py
+++ b/ufpy/typ/type_alias.py
@@ -1,6 +1,6 @@
 from typing import Never
 
-from .protocols import LikeDict
+from ufpy.typ.protocols import LikeDict
 
 __all__ = (
     'AnyCollection',

--- a/ufpy/udict.py
+++ b/ufpy/udict.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Generic, Iterator, overload, TypeVar, Callable
 
-from .cmp import cmp_generator
-from .math_op import i_generator, r_generator
-from .typ import AnyDict, AnyCollection
-from .utils import set_items_for_several_keys, get_items_for_several_keys, del_items_for_several_keys
+from ufpy.cmp import cmp_generator
+from ufpy.math_op import i_generator, r_generator
+from ufpy.typ import AnyDict, AnyCollection
+from ufpy.utils import set_items_for_several_keys, get_items_for_several_keys, del_items_for_several_keys
 
 __all__ = (
     'UDict',
@@ -243,9 +243,6 @@ class UDict(Generic[KT, VT, CDV]):
         return item in self.__dict
     
     # Transform to other types
-    def __str__(self) -> str:
-        return str(self.__dict)
-
     def __repr__(self) -> str:
         return f'u{self.__dict}'
 

--- a/ufpy/ustack.py
+++ b/ufpy/ustack.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar, Iterable, Callable
 
-from .cmp import cmp_generator
-from .math_op import r_generator, i_generator
-from .typ import AnyCollection, NumberLiteral, SupportsMul, SupportsTrueDiv, Empty
+from ufpy.cmp import cmp_generator
+from ufpy.math_op import r_generator, i_generator
+from ufpy.typ import AnyCollection, NumberLiteral, SupportsMul, SupportsTrueDiv, Empty
 
 __all__ = (
     "UStack",

--- a/ufpy/utils.py
+++ b/ufpy/utils.py
@@ -6,7 +6,7 @@ __all__ = (
 
 from typing import TypeVar
 
-from .typ import SupportsGet, SupportsSetItem, SupportsDelItem, AnyCollection
+from ufpy.typ import SupportsGet, SupportsSetItem, SupportsDelItem, AnyCollection
 
 KT = TypeVar('KT')
 VT = TypeVar('VT')

--- a/upload_testpypi.bat
+++ b/upload_testpypi.bat
@@ -1,0 +1,10 @@
+@echo off
+py -3.12 -m pip install --upgrade pip
+py -3.12 -m pip install setuptools twine
+py -3.12 setup.py sdist
+
+py -3.12 -m twine upload --repository testpypi dist\*
+
+rd /s /q ufpy.egg-info
+rd /s /q dist
+rd /s /q build


### PR DESCRIPTION
closes #31

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes import path issues, removes the `__str__` method from the `UDict` class, updates the `setup.py` configuration, and enhances documentation. Additionally, a new script for uploading to TestPyPI has been added.

* **Bug Fixes**:
    - Fixed import paths in multiple modules to use absolute imports instead of relative ones.
* **Enhancements**:
    - Removed the `__str__` method from the `UDict` class, relying solely on the `__repr__` method for string representation.
* **Build**:
    - Updated `setup.py` to include the `typ` subpackage in the list of packages.
    - Cleared the `install_requires` list in `setup.py`.
* **Documentation**:
    - Updated `examples/udict.md` to remove references to the `str()` method and clarify the usage of `repr()` in print statements.
* **Chores**:
    - Added a new script `upload_testpypi.bat` for uploading the package to TestPyPI.

<!-- Generated by sourcery-ai[bot]: end summary -->