### PR TITLE
gh-51: Fix module installation error with ```requests```

### DIFF
--- a/ufpy/github/download.py
+++ b/ufpy/github/download.py
@@ -5,7 +5,7 @@ from tempfile import gettempdir
 from typing import Iterable
 from zipfile import ZipFile
 
-from requests import get
+import requests
 
 from ufpy.path import UOpen
 
@@ -62,7 +62,7 @@ class UGithubDownloader:
 
     def __enter__(self):
         url = f'https://github.com/{self.__repo}/archive/{self.__branch}.zip'
-        r = get(url, timeout=10)
+        r = requests.get(url, timeout=10)
 
         if not r.ok:
             r.raise_for_status()
@@ -85,7 +85,7 @@ class UGithubDownloader:
         download_path = f'{self.__base_download_path}/{download_path}'
 
         url = f'https://raw.githubusercontent.com/{self.__repo}/{self.__branch}/{file_path}'
-        r = get(url)
+        r = requests.get(url)
 
         if not r.ok:
             r.raise_for_status()


### PR DESCRIPTION
I think you are working with an old version of the requests module, because the latest version specifies at the very beginning how the get() object should be used:
<img width="459" alt="Снимок экрана 2024-08-31 в 17 42 06" src="https://github.com/user-attachments/assets/4cbd1d58-3bed-42fe-8144-e2d8ce2b8b91">

**Proposal:**

```import requests```

```requests.get()```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the module installation error by updating the code to use 'requests.get()' explicitly, ensuring compatibility with the latest version of the 'requests' library.

Bug Fixes:
- Fix module installation error by explicitly using 'requests.get()' instead of 'get()' to ensure compatibility with the latest version of the 'requests' module.

<!-- Generated by sourcery-ai[bot]: end summary -->