### PR TITLE
Pylint fix up to 9.86. Deprecation of Stack

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -39,4 +39,4 @@ jobs:
         python -m pip install -r ./requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files 'ufpy/*.py') --fail-under=7.0
+        pylint $(git ls-files 'ufpy/*.py') --fail-under=7.0 --max-line-length 120

--- a/ufpy/__init__.py
+++ b/ufpy/__init__.py
@@ -1,8 +1,24 @@
+"""
+Library with some useful features like classes, functions and variables.
+
+Online docs: https://honey-team.ru/ufpy-website
+"""
+
+from ufpy.cmp import *
+from ufpy.math_op import *
+from ufpy.udict import *
+from ufpy.utils import *
+from ufpy.typ import *
+from ufpy.ustl import *
+from ufpy.path import *
+from ufpy.github import *
+
 # Deprecated
 def __deprecated(deprecated_name: str, x, start_version: str, end_version: str):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
     when the function is used."""
+    # pylint: disable=import-outside-toplevel
     from functools import wraps
     from warnings import warn, simplefilter
 
@@ -17,26 +33,4 @@ def __deprecated(deprecated_name: str, x, start_version: str, end_version: str):
         return x(*args, **kwargs)
     return new_func
 
-
-__version__ = '0.2.1.1'
-from ufpy.cmp import *
-from ufpy.math_op import *
-from ufpy.udict import *
-from ufpy.utils import *
-
-# Typing package
-__typ_version__ = '0.2'
-from ufpy.typ import *
-
-# Ustl package
-__ustl_version__ = '0.1'
-from ufpy.ustl import *
 UStack = __deprecated("UStack", Stack, '0.2', '0.5')
-
-# Path package
-__path_version__ = '0.2'
-from ufpy.path import *
-
-# GitHub package
-__github_version__ = '0.1'
-from ufpy.github import *

--- a/ufpy/__init__.py
+++ b/ufpy/__init__.py
@@ -33,4 +33,5 @@ def __deprecated(deprecated_name: str, x, start_version: str, end_version: str):
         return x(*args, **kwargs)
     return new_func
 
+Stack = __deprecated("Stack", None, '0.3', '0.5')
 UStack = __deprecated("UStack", Stack, '0.2', '0.5')

--- a/ufpy/__init__.py
+++ b/ufpy/__init__.py
@@ -33,5 +33,5 @@ def __deprecated(deprecated_name: str, x, start_version: str, end_version: str):
         return x(*args, **kwargs)
     return new_func
 
-Stack = __deprecated("Stack", None, '0.3', '0.5')
+Stack = __deprecated("Stack", Stack, '0.3', '0.5')
 UStack = __deprecated("UStack", Stack, '0.2', '0.5')

--- a/ufpy/cmp.py
+++ b/ufpy/cmp.py
@@ -41,7 +41,7 @@ def cmp_generator(t: Type[T]) -> Type[T]:
     Online docs: soon!
     """
 
-    if not '__eq__' in t.__dict__:
+    if  '__eq__' not in t.__dict__:
         t.__eq__ = lambda self, x: t.__cmp__(self, x) == 0
     if not '__ne__' in t.__dict__:
         t.__ne__ = lambda self, x: t.__cmp__(self, x) != 0

--- a/ufpy/cmp.py
+++ b/ufpy/cmp.py
@@ -1,18 +1,24 @@
+"""
+Module with generator compare magic methods
+"""
+
 __all__ = (
     'cmp_generator',
     'Comparable',
 )
 
-from typing import Generic, Protocol, Type, TypeVar
+from typing import Protocol, Type, TypeVar
 
 T = TypeVar('T', bound=type)
 
 def cmp_generator(t: Type[T]) -> Type[T]:
-    '''
-    Decorator for auto generate compare magic methods (`__eq__()`, `__ne__()`, `__lt__()`, `__le__()`, `__gt__()`, `__ge__()`).
-    You should add `__cmp__()` method in your class. If your object more that other, `__cmp__()` should return positive number.
+    """
+    Decorator for auto generate compare magic methods
+    (`__eq__()`, `__ne__()`, `__lt__()`, `__le__()`, `__gt__()`, `__ge__()`).
+    You should add `__cmp__()` method in your class. If your object more that other, `__cmp__()`
+    should return positive number.
     If less that other, `__cmp__()` should return negative number. If equals, `__cmp__()` should return zero.
-    
+
     `Note:`
     If you defined one of compare methods, they won't redefine.
 
@@ -24,20 +30,21 @@ def cmp_generator(t: Type[T]) -> Type[T]:
             self.num = num
         def __cmp__(self, other: int) -> int:
             return self.num - self.other
-    
+
     a = A(2)
     print(a > 1) # True
     print(a < 2) # False
     print(a >= 3) # False
     print(a <= 4) # True
     ```
-    
+
     Online docs: soon!
-    '''
-    
+    """
+
     if not '__eq__' in t.__dict__:
         t.__eq__ = lambda self, x: t.__cmp__(self, x) == 0
-        t.__ne__ = lambda self, x: not t.__eq__(self, x)
+    if not '__ne__' in t.__dict__:
+        t.__ne__ = lambda self, x: t.__cmp__(self, x) != 0
 
     if not '__lt__' in t.__dict__:
         t.__lt__ = lambda self, x: t.__cmp__(self, x) < 0
@@ -48,10 +55,10 @@ def cmp_generator(t: Type[T]) -> Type[T]:
         t.__gt__ = lambda self, x: t.__cmp__(self, x) > 0
     if not '__ge__' in t.__dict__:
         t.__ge__ = lambda self, x: t.__cmp__(self, x) >= 0
-    
+
     return t
 
 CT = TypeVar('CT')
 
-class Comparable(Protocol, Generic[CT]):
+class Comparable(Protocol[CT]): # pylint: disable=too-few-public-methods, missing-class-docstring
     def __cmp__(self, other: CT) -> int: ...

--- a/ufpy/github/__init__.py
+++ b/ufpy/github/__init__.py
@@ -1,3 +1,10 @@
+"""
+Library for simplifying working with GitHub.
+
+Key features:
+- Download repositories, files, folders from GitHub public repositories.
+"""
+
 # Download
 import ufpy.github.download
 from ufpy.github.download import UGithubDownloader

--- a/ufpy/math_op.py
+++ b/ufpy/math_op.py
@@ -1,3 +1,7 @@
+"""
+Module with generators of math operations magic methods (assigment and reverse) using basic ones
+"""
+
 __all__ = (
     'i_generator',
     'r_generator',
@@ -9,6 +13,10 @@ from typing import Type, TypeVar
 T = TypeVar('T')
 
 def i_generator(t: Type[T]) -> Type[T]:
+    """
+    Generate assignment magic methods using basic ones
+    """
+    # pylint: disable=too-many-branches
     if '__add__' in t.__dict__:
         t.__iadd__ = t.__add__
     if '__sub__' in t.__dict__:
@@ -35,10 +43,13 @@ def i_generator(t: Type[T]) -> Type[T]:
         t.__ior__ = t.__or__
     if '__xor__' in t.__dict__:
         t.__ixor__ = t.__xor__
-    
     return t
 
 def r_generator(t: Type[T]) -> Type[T]:
+    """
+    Generate reverse magic methods using basic ones
+    """
+    # pylint: disable=too-many-branches
     if '__add__' in t.__dict__:
         t.__radd__ = t.__add__
     if '__sub__' in t.__dict__:
@@ -65,5 +76,4 @@ def r_generator(t: Type[T]) -> Type[T]:
         t.__ror__ = t.__or__
     if '__xor__' in t.__dict__:
         t.__rxor__ = t.__xor__
-
     return t

--- a/ufpy/path/__init__.py
+++ b/ufpy/path/__init__.py
@@ -1,3 +1,10 @@
+"""
+`ufpy.path` library
+
+Classes and functions for simplifying working with files
+"""
+# pylint: disable=cyclic-import
+
 from ufpy.path.files import *
 from ufpy.path.json_file_updater import *
 from ufpy.path.tools import *

--- a/ufpy/path/files.py
+++ b/ufpy/path/files.py
@@ -1,38 +1,83 @@
+"""
+Module which provides `UOpen` class for simplifying open files for read and write. UOpen automaticlly creates
+directories when they weren't existing.
+"""
+
 import os
-from typing import AnyStr, Iterable
+from typing import AnyStr, Literal
 
 
 __all__ = (
     'UOpen',
 )
 
+from ufpy import is_iterable
+
+
 class UOpen:
+    """
+    Class for simplifying working with files.
+
+    Key features:
+    - Auto create location of file (e.g. if path = '~/dev/test.txt' then program will create this path if not exists).
+    - Work together with strings and bytes
+    """
     def __init__(
-            self, filepath: str, mode: str = "r", encoding: str = 'utf-8'
+            self, filepath: str,
+            mode: Literal["r+", "+r", "rt+", "r+t", "+rt", "tr+", "t+r", "+tr", "w+", "+w", "wt+", "w+t", "+wt", "tw+",
+            "t+w", "+tw", "a+", "+a", "at+", "a+t", "+at", "ta+", "t+a", "+ta", "x+", "+x", "xt+", "x+t", "+xt", "tx+",
+            "t+x", "+tx", "w", "wt", "tw", "a", "at", "ta", "x", "xt", "tx", "r", "rt", "tr", "U", "rU", "Ur", "rtU",
+            "rUt", "Urt", "trU", "tUr", "Utr"] = "r", encoding: str = 'utf-8'
     ):
         self.__path = filepath
         self.__mode = mode
         self.__encoding = encoding
-
-    def __enter__(self):
         directory = '/'.join(self.__path.split('/')[:-1]) or '\\'.join(self.__path.split('\\')[:-1])
-
-        os.makedirs(directory, exist_ok=True)
-
-        self.__f = open(file=self.__path, mode=self.__mode, encoding=self.__encoding)
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.__f.close()
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        self.__f = open(file=self.__path, mode=self.__mode, encoding=self.__encoding) # pylint: disable=(consider-using-with
 
     def write(self, data: AnyStr):
+        """
+        Write data to file
+        """
         self.__f.write(data)
 
-    def writelines(self, lines: Iterable[AnyStr]):
+    def writelines(self, *lines: AnyStr | list[AnyStr]):
+        """
+        Write lines to file
+        """
+        nl = []
+        for i in lines:
+            nl += i if is_iterable(i) else [i]
+        lines = nl
+
+        lines = [i.decode(self.__encoding) if isinstance(i, bytes) else i for i in lines]
+
         self.__f.writelines(lines)
 
+
     def read(self, n: int = -1) -> AnyStr:
+        """
+        Read text from file
+        """
         return self.__f.read(n)
 
     def readlines(self, hint: int = -1) -> list[AnyStr]:
+        """
+        Read lines from file
+        """
         return self.__f.readlines(hint)
+
+    def close(self) -> None:
+        """
+        Close file
+        """
+        if self.__f:
+            self.__f.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/ufpy/path/tools.py
+++ b/ufpy/path/tools.py
@@ -5,6 +5,9 @@ __all__ = (
 import os
 
 def number_of_files_with_extensions(path, extension) -> int:
+    """
+    Count number of files with specified extension in specified path.
+    """
     r = 0
     for p in os.listdir(path):
         if os.path.isdir(f'{path}/{p}'):

--- a/ufpy/typ/protocols.py
+++ b/ufpy/typ/protocols.py
@@ -22,6 +22,8 @@ __all__ = (
     'SupportsSorted',
 )
 
+# pylint: disable=missing-class-docstring, too-few-public-methods, missing-function-docstring, too-many-ancestors
+
 from typing import Protocol, TypeVar, Iterable
 
 # Dicts/collections

--- a/ufpy/typ/type_alias.py
+++ b/ufpy/typ/type_alias.py
@@ -1,3 +1,7 @@
+"""
+Module with some useful type alias
+"""
+
 from typing import Never, Iterable
 
 from ufpy.typ.protocols import LikeDict, SupportsTrueDiv
@@ -15,6 +19,6 @@ type AnyDict[KT, VT] = dict[KT, VT] | LikeDict[KT, VT]
 
 type NumberLiteral = int | float
 
-type Empty[T] = T[Never]
+type Empty[T] = T[Never] # pylint: disable=unsubscriptable-object
 
 type SupportsAvg = SupportsTrueDiv[int] | Iterable[SupportsTrueDiv[int]]

--- a/ufpy/udict.py
+++ b/ufpy/udict.py
@@ -1,3 +1,7 @@
+"""
+UDict is a class for simplyfing working with python dictionaries.
+"""
+
 from __future__ import annotations
 
 from typing import Generic, Iterator, overload, TypeVar, Callable
@@ -16,7 +20,7 @@ VT = TypeVar('VT')
 CDV = TypeVar('CDV')
 DV = TypeVar('DV')
 
-class _ClassDefault:
+class _ClassDefault: # pylint: disable=too-few-public-methods
     ...
 
 @cmp_generator
@@ -42,17 +46,18 @@ class UDict(Generic[KT, VT, CDV]):
             dictionary = dictionary.dictionary
         self.__dict = dictionary or kwargs
         self.__default = default
-    
+
     # dictionary
     @property
     def dictionary(self) -> dict[KT, VT]:
         """
         UDict's dictionary. A regular Python Dictionary.
         
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-dictionary-dictkt-vt
+        Online docs:
+        https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-dictionary-dictkt-vt
         """
         return self.__dict
-    
+
     @dictionary.setter
     def dictionary(self, value: AnyDict[KT, VT]):
         if isinstance(value, UDict):
@@ -79,7 +84,8 @@ class UDict(Generic[KT, VT, CDV]):
         """
         All dict's values
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-values-listvt
+        Online docs:
+        https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-values-listvt
         """
         return list(self.__dict.values())
 
@@ -93,24 +99,26 @@ class UDict(Generic[KT, VT, CDV]):
         """
         All dict's items
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-items-listtuplekt-vt
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#property-settable-items-listtuplekt-vt
         """
         return list(zip(self.keys, self.values))
 
     @items.setter
     def items(self, value: AnyCollection[tuple[KT, VT] | list[KT | VT]]):
         self.__dict = dict(value)
-    
+
     # default
     @property
     def default(self) -> CDV:
         """
-        The value that will be returned when .get() function or the [] operator are called if the entered key is not in the UDict
+        The value that will be returned when .get() function or the [] operator are called
+        if the entered key is not in the UDict
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#property-settable-default-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#property-settable-default-cdv
         """
         return self.__default
-    
+
     @default.setter
     def default(self, value: CDV):
         self.__default = value
@@ -123,7 +131,8 @@ class UDict(Generic[KT, VT, CDV]):
         Args:
             func: First argument of function is key, second is value. Returns new value
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__call__func-callablekt-vt-vt-udictkt-vt-cdv
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__call__func-callablekt-vt-vt-udictkt-vt-cdv
         """
         new_dict = self.__dict
         for k, v in self:
@@ -133,22 +142,22 @@ class UDict(Generic[KT, VT, CDV]):
     # reverse integers
     def __neg__(self) -> UDict[KT, VT, CDV]:
         return self(lambda k, v: -v)
-    
+
     # reverse
     def reverse(self) -> UDict[KT, VT, CDV]:
         """
         Reverses UDict and returns it.
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#reverse-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#reverse-udictkt-vt-cdv
         """
-        self.__dict = self.reversed().__dict
+        self.__dict = self.reversed().dictionary
         return self
 
     def reversed(self) -> UDict[KT, VT, CDV]:
         """
         Returns reversed UDict, but doesn't change it
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#reversed-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#reversed-udictkt-vt-cdv
         """
         keys, values = list(self.__dict.keys())[::-1], list(self.__dict.values())[::-1]
         return UDict(dict(list(zip(keys, values))))
@@ -164,16 +173,16 @@ class UDict(Generic[KT, VT, CDV]):
         """
         Sorts UDict and returns it
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#sort-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#sort-udictkt-vt-cdv
         """
-        self.__dict = self.sorted().__dict
+        self.__dict = self.sorted().dictionary
         return self
 
     def sorted(self) -> UDict[KT, VT, CDV]:
         """
         Returns sorted UDict, but doesn't change it
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#sorted-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#sorted-udictkt-vt-cdv
         """
         keys = sorted(list(self.__dict.keys()))
         values = get_items_for_several_keys(self.__dict, keys)
@@ -194,7 +203,7 @@ class UDict(Generic[KT, VT, CDV]):
             indexes = list(range(start, stop + 1, step))
             return [list(self.__dict.keys())[i - 1] for i in indexes]
         return [key]
-    
+
     def __getitem__(self, key: KT | int | slice) -> UDict[KT, VT, DV] | VT:
         keys = self.__get_keys_from_slice_or_int(key)
 
@@ -250,7 +259,7 @@ class UDict(Generic[KT, VT, CDV]):
         ValueError: You defined 0 or 2 or 3 params (from `key`, `index` and `value`)
         IndexError: index is bigger that length of dict
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#get
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#get
         """
         if key and index and value:
             raise ValueError(
@@ -288,24 +297,24 @@ class UDict(Generic[KT, VT, CDV]):
         """
         Implements `len(self)`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__len__-int
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__len__-int
         """
         return len(self.__dict)
-    
+
     def __iter__(self) -> Iterator[tuple[KT, VT]]:
         """
         Implements `iter(self)`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__iter__-iteratortuplekt-vt
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__iter__-iteratortuplekt-vt
         """
         return iter(self.__dict.items())
-    
+
     # Booleans
     def is_empty(self) -> bool:
         """
         Returns `True` if `len(self)` equals `0`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#is_empty-bool
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#is_empty-bool
         """
         return len(self) == 0
 
@@ -313,7 +322,7 @@ class UDict(Generic[KT, VT, CDV]):
         """
         Returns `False` if `len(self)` equals `0`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__bool__-bool
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__bool__-bool
         """
         return not self.is_empty()
 
@@ -321,19 +330,20 @@ class UDict(Generic[KT, VT, CDV]):
         """
         Returns `True` if `item` is in `UDict`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__contains__item-tuplekt-vt-listkt-vt-kt-bool
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__contains__item-tuplekt-vt-listkt-vt-kt-bool
         """
         if isinstance(item, (list, tuple)):
             k, v = item
             return k in self.__dict and self.__dict.get(k, self.__default) == v
         return item in self.__dict
-    
+
     # Transform to other types
     def __repr__(self) -> str:
         """
         Transforms `UDict` to `str`
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__repr__-str
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__repr__-str
         """
         return f'u{self.__dict}'
 
@@ -341,96 +351,102 @@ class UDict(Generic[KT, VT, CDV]):
         """
         Returns UDict's hash
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__hash__-int
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__hash__-int
         """
         return hash(self.__repr__())
-    
+
     # Comparing
     def __cmp__(self, other: dict[KT, VT] | UDict[KT, VT, CDV]) -> int:
         """
         Returns `len(self) - len(other)` (this method is used by `@cmp_generator`)
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__cmp__other-dictkt-vt-udictkt-vt-cdv-int
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__cmp__other-dictkt-vt-udictkt-vt-cdv-int
         """
         return len(self) - len(other)
-    
+
     def __eq__(self, other: dict[KT, VT] | UDict[KT, VT, CDV]) -> bool:
         """
         Returns True if UDict.dictionary is equal to other UDict.dictionary / UDict.dictionary is equal to dict
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__eq__other-dictkt-vt-udictkt-vt-cdv-bool
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__eq__other-dictkt-vt-udictkt-vt-cdv-bool
         """
         if isinstance(other, UDict):
             other = other.dictionary
         return self.__dict == other
-    
+
     # Math operations
     def __add__(self, other: dict[KT, VT] | UDict[KT, VT, CDV]) -> UDict[KT, VT, CDV]:
+        # pylint: disable=line-too-long
         """
         Combines 2 UDict / 1 UDict and 1 Dictionary
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__add__other-dictkt-vt-udictkt-vt-cdv-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__add__other-dictkt-vt-udictkt-vt-cdv-udictkt-vt-cdv
         """
         new_dict = self.__dict.copy()
-        
+
         if isinstance(other, UDict):
             other: dict[KT, VT] = other.dictionary
-        
+
         for k, v in other.items():
             new_dict[k] = v
         return UDict(new_dict)
-    
+
     def __sub__(self, other: dict[KT, VT] | UDict[KT, VT, CDV]) -> UDict[KT, VT, CDV]:
+        # pylint: disable=line-too-long
         """
         Subtracts from UDict another UDict / from UDict a regular dict
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__sub__other-dictkt-vt-udictkt-vt-cdv-udictkt-vt-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__sub__other-dictkt-vt-udictkt-vt-cdv-udictkt-vt-cdv
         """
         new_dict = self.__dict.copy()
         if isinstance(other, UDict):
             other: dict[KT, VT] = other.dictionary
-        
+
         for k, v in other.items():
             if new_dict.get(k) == v:
                 del new_dict[k]
         return UDict(new_dict)
-    
+
     def __mul__(
             self, other: dict[KT, float | int] | UDict[KT, float | int, DV] | float | int
     ) -> UDict[KT, VT, CDV]:
         """
         Multiplies each value by another value with the same key or all values by integer or float number
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__mul__other-dictkt-float-int-udictkt-float-int-dv-float-int-udictkt-supportsmul-cdv
+        Online docs:
+        https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__mul__other-dictkt-float-int-udictkt-float-int-dv-float-int-udictkt-supportsmul-cdv
         """
         new_dict = self.__dict.copy()
-        
+
         if isinstance(other, UDict):
             other: dict[KT, VT] = other.dictionary
         if isinstance(other, (int, float)):
-            other = dict([(k, other) for k in new_dict.keys()])
-        
+            other = {k: other for k in new_dict.keys()}
+
         for k, v in other.items():
             new_dict[k] *= v
-        
+
         return UDict(new_dict)
 
     def __truediv__(
             self, other: dict[KT, float | int] | UDict[KT, float | int, DV] | float | int
     ) -> UDict[KT, VT, CDV]:
+        # pylint: disable=line-too-long
         """
         Divides each value by another value with the same key or all values by integer or float number
 
-        Online docs: https://honey-team.github.io/ufpy-website/main/useful_classes/udict/#__truediv__other-dictkt-float-int-udictkt-float-int-dv-float-int-udictkt-supportstruediv-cdv
+        Online docs: https://honey-team.ru/ufpy-website/main/useful_classes/udict/#__truediv__other-dictkt-float-int-udictkt-float-int-dv-float-int-udictkt-supportstruediv-cdv
         """
         new_dict = self.__dict.copy()
-        
+
         if isinstance(other, UDict):
             other: dict[KT, VT] = other.dictionary
         if isinstance(other, (int, float)):
-            other = dict([(k, other) for k in new_dict.keys()])
-        
+            other = {k: other for k in new_dict.keys()}
+
         for k, v in other.items():
             new_dict[k] /= v
-        
+
         return UDict(new_dict)

--- a/ufpy/ustl/__init__.py
+++ b/ufpy/ustl/__init__.py
@@ -1,1 +1,5 @@
+"""
+Library with some useful classes, function from C++ STL, but in Python
+"""
+
 from ufpy.ustl.stack import *

--- a/ufpy/ustl/stack.py
+++ b/ufpy/ustl/stack.py
@@ -6,21 +6,24 @@ from ufpy.cmp import cmp_generator
 from ufpy.math_op import r_generator, i_generator
 from ufpy.typ import AnyCollection, NumberLiteral, SupportsMul, SupportsTrueDiv, Empty
 
+# Marked for deletion in 0.5
+# pylint: disable=all
+
 __all__ = (
     "Stack",
 )
 
 T = TypeVar("T")
-T2 = TypeVar("T2")
+T2 = TypeVar("T2") # pylint: disable=invalid-name
 
-def convert_to_stack(other: Stack[T] | AnyCollection[T] | T) -> Stack[T]:
+def _convert_to_stack(other: Stack[T] | AnyCollection[T] | T) -> Stack[T]:
     if isinstance(other, Stack):
         return other
     if isinstance(other, (list, tuple)):
         return Stack(iterable=other)
     return Stack(other)
 
-def convert_to_list_for_mul_and_div(other: Stack[T] | AnyCollection[T] | T, __len: int = None) -> list[T]:
+def _convert_to_list_for_mul_and_div(other: Stack[T] | AnyCollection[T] | T, __len: int = None) -> list[T]:
     if isinstance(other, Stack):
         return other.elements
     if isinstance(other, (list, tuple)):
@@ -85,6 +88,9 @@ class Stack(Generic[T]):
         return Stack(iterable=self.__elements)
 
     def remove(self, *items: T) -> Stack[T]:
+        """
+        Remove elements from stack
+        """
         for i in items:
             self.__elements.remove(i)
         return Stack(iterable=self.__elements)
@@ -109,19 +115,19 @@ class Stack(Generic[T]):
 
     # math operations
     def __add__(self, other: Stack[T2] | AnyCollection[T2] | T2) -> Stack[T | T2]:
-        other = convert_to_stack(other)
+        other = _convert_to_stack(other)
         result = self.copy()
         return result.push(*other.elements)
 
     def __sub__(self, other: Stack[T] | AnyCollection[T] | T) -> Stack[T]:
-        other = convert_to_stack(other)
+        other = _convert_to_stack(other)
         result = self.copy()
         return result.remove(*other.elements)
 
     def __mul__(
         self: Stack[SupportsMul], other: Stack[NumberLiteral] | AnyCollection[NumberLiteral] | NumberLiteral
     ) -> Stack[SupportsMul]:
-        other = convert_to_list_for_mul_and_div(other, len(self))
+        other = _convert_to_list_for_mul_and_div(other, len(self))
 
         def mul(i: int, v: SupportsMul) -> SupportsMul:
             return v * other[i]
@@ -131,7 +137,7 @@ class Stack(Generic[T]):
     def __truediv__(
         self: Stack[SupportsTrueDiv], other: Stack[NumberLiteral] | AnyCollection[NumberLiteral] | NumberLiteral
     ) -> Stack[SupportsTrueDiv]:
-        other = convert_to_list_for_mul_and_div(other, len(self))
+        other = _convert_to_list_for_mul_and_div(other, len(self))
 
         def div(i: int, v: SupportsTrueDiv) -> SupportsTrueDiv:
             return v / other[i]

--- a/ufpy/utils.py
+++ b/ufpy/utils.py
@@ -1,3 +1,7 @@
+"""
+Some useful utils
+"""
+
 from __future__ import annotations
 
 __all__ = (
@@ -11,9 +15,8 @@ __all__ = (
 )
 
 from collections import Counter
-from typing import TypeVar, Iterable, overload, TYPE_CHECKING
+from typing import TypeVar, Iterable, TYPE_CHECKING
 
-from ufpy.typ.protocols import SupportsSorted
 
 if TYPE_CHECKING:
     from ufpy import SupportsTrueDiv, SupportsCompare
@@ -26,24 +29,36 @@ T = TypeVar('T')
 
 
 def get_items_for_several_keys(o: SupportsGet[KT, VT], keys: AnyCollection[KT], default: DV = None) -> list[VT | DV]:
+    """
+    Get items for several keys. You can also specify default value if key is missing
+    """
     return [o.get(k, default) for k in keys]
 
 
 def set_items_for_several_keys(
         o: SupportsSetItem[KT, VT], keys: AnyCollection[KT], values: AnyCollection[VT]
 ) -> SupportsSetItem[KT, VT]:
-    for i, k in enumerate(keys):
-        o[k] = values[i]
+    """
+    Set items for several keys
+    """
+    for k, v in zip(keys, values):
+        o[k] = v
     return o
 
 
 def del_items_for_several_keys(o: SupportsDelItem[KT, VT], keys: AnyCollection[KT]) -> SupportsDelItem[KT, VT]:
+    """
+    Delete items for several keys
+    """
     for k in keys:
         del o[k]
     return o
 
 
 def is_iterable(o: object) -> bool:
+    """
+    Check that object is iterable
+    """
     return isinstance(o, Iterable)
 
 


### PR DESCRIPTION
## Description `(optional)`

Fixed pylint warning up to 9.86 score. Stack is now deprecated and will be deleted in 0.5

## TO-DO list `(optional)`

<!-- Type here TO-DO list using checkboxes
- [ ] Feature
- [x] Made feature
-->

## Issue you want to close `(optional)`

closes #<!-- type here id of issue you want to close -->

## Summary by Sourcery

This pull request introduces new features for file handling, JSON manipulation, and GitHub downloading, improves documentation and type hinting, deprecates the Stack class, and updates the Pylint configuration.

New Features:
- Introduce the `UOpen` class in `ufpy/path/files.py` to simplify file operations, including automatic directory creation.
- Introduce the `JsonFileUpdater` class to simplify working with JSON files, allowing them to be treated like Python dictionaries.
- Introduce the `UGithubDownloader` class to simplify downloading files and folders from GitHub repositories.

Enhancements:
- Improve the documentation and docstrings for the `UOpen`, `UGithubDownloader`, and `JsonFileUpdater` classes.
- Improve type hinting throughout the project.

CI:
- Update the Pylint configuration to achieve a code score of 9.86.

Chores:
- Deprecate the `Stack` class, which will be removed in version 0.5.